### PR TITLE
Do not use unnecessary reference in ArrayWalker

### DIFF
--- a/src/ArrayWalker.php
+++ b/src/ArrayWalker.php
@@ -27,7 +27,7 @@ class ArrayWalker
                 return null;
             }
 
-            $array = &$array[array_shift($path)];
+            $array = $array[array_shift($path)];
         }
 
         return $array;


### PR DESCRIPTION
https://gist.github.com/amcsi/a4056acaa383160c9448af1aff35250c
https://gist.github.com/amcsi/63de44f8baba1d3c178ead69ac2c9930
With an iteration count of 1000000, I'm getting these microtime benchmark results (in seconds):
value: 5.6879
reference: 5.7214

The speeds are roughly equivalent, so there's probably no reason to use references.